### PR TITLE
feat: add pool col to node view

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Original repo - https://github.com/derailed/k9s
 
 ## Features added to this fork
 
+- Add a column to display the pool (segment.com/pool) next to nodes in the nodes view
 
 ---
 

--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -35,7 +35,8 @@ func (Node) Header(string) model1.Header {
 	return model1.Header{
 		model1.HeaderColumn{Name: "NAME"},
 		model1.HeaderColumn{Name: "STATUS"},
-		model1.HeaderColumn{Name: "ROLE"},
+		model1.HeaderColumn{Name: "ROLE", Wide: true},
+		model1.HeaderColumn{Name: "POOL"},
 		model1.HeaderColumn{Name: "ARCH", Wide: true},
 		model1.HeaderColumn{Name: "TAINTS"},
 		model1.HeaderColumn{Name: "VERSION"},
@@ -82,6 +83,7 @@ func (n Node) Render(o interface{}, ns string, r *model1.Row) error {
 	roles := make(sort.StringSlice, 10)
 	nodeRoles(&no, roles)
 	sort.Sort(roles)
+	pool := nodePool(&no)
 
 	podCount := strconv.Itoa(oo.PodCount)
 	if pc := oo.PodCount; pc == -1 {
@@ -92,6 +94,7 @@ func (n Node) Render(o interface{}, ns string, r *model1.Row) error {
 		no.Name,
 		join(statuses, ","),
 		join(roles, ","),
+		pool,
 		no.Status.NodeInfo.Architecture,
 		strconv.Itoa(len(no.Spec.Taints)),
 		no.Status.NodeInfo.KubeletVersion,
@@ -193,6 +196,15 @@ func nodeRoles(node *v1.Node, res []string) {
 	if empty(res) {
 		res[index] = MissingValue
 	}
+}
+
+func nodePool(node *v1.Node) string {
+	for k, v := range node.Labels {
+		if k == "segment.com/pool" {
+			return v
+		}
+	}
+	return UnsetValue
 }
 
 func getIPs(addrs []v1.NodeAddress) (iIP, eIP string) {

--- a/internal/render/node_test.go
+++ b/internal/render/node_test.go
@@ -25,8 +25,8 @@ func TestNodeRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "minikube", r.ID)
-	e := model1.Fields{"minikube", "Ready", "master", "amd64", "0", "v1.15.2", "4.15.0", "192.168.64.107", "<none>", "0", "10", "20", "0", "0", "4000", "7874"}
-	assert.Equal(t, e, r.Fields[:16])
+	e := model1.Fields{"minikube", "Ready", "master", "", "amd64", "0", "v1.15.2", "4.15.0", "192.168.64.107", "<none>", "0", "10", "20", "0", "0", "4000", "7874"}
+	assert.Equal(t, e, r.Fields[:17])
 }
 
 func BenchmarkNodeRender(b *testing.B) {


### PR DESCRIPTION
Add `segment.com/pool` value as the pool col to the node view

![CleanShot 2024-06-06 at 12 57 17](https://github.com/segmentio/k9s/assets/7345249/24aae8d6-b553-4914-b5b5-0637a714bfa4)
